### PR TITLE
primaryKey does not recognized when entity name is different from entity class name (Core Data)

### DIFF
--- a/SyncKit/Classes/CoreData/QSCoreDataChangeManager.m
+++ b/SyncKit/Classes/CoreData/QSCoreDataChangeManager.m
@@ -136,7 +136,7 @@ static NSString * const QSCloudKitTimestampKey = @"QSCloudKitTimestampKey";
         
         for (NSEntityDescription *entityDescription in entities) {
             NSError *error = nil;
-            NSString *primaryKey = [self identifierFieldNameForEntityOfType:entityDescription.managedObjectClassName];
+            NSString *primaryKey = [self identifierFieldNameForEntityOfType:entityDescription.name];
             NSArray *objectIDs;
             if (primaryKey) {
                 //Get object identifiers using primary key


### PR DESCRIPTION
Hi! There is another place with confusion between entity name and class name. This could produce duplicate entities in case and you have named you entities different then entity classes and use multiple devices to sync your core data DB