### PR TITLE
fix primaryKey attributeName to upload for SyncedEntity

### DIFF
--- a/SyncKit/Classes/CoreData/QSCoreDataChangeManager.m
+++ b/SyncKit/Classes/CoreData/QSCoreDataChangeManager.m
@@ -461,7 +461,9 @@ static NSString * const QSCloudKitTimestampKey = @"QSCloudKitTimestampKey";
         NSString *primaryKey = [self identifierFieldNameForEntityOfType:entityType];
         //Add attributes
         [[entityDescription attributesByName] enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull attributeName, NSAttributeDescription * _Nonnull attributeDescription, BOOL * _Nonnull stop) {
-            if ((entityState == QSSyncedEntityStateNew || [changedKeys containsObject:attributeName]) && [primaryKey isEqualToString:attributeName] == NO) {
+            if ((entityState == QSSyncedEntityStateNew || [changedKeys containsObject:attributeName]) 
+//&& [primaryKey isEqualToString:attributeName] == NO
+               ) {
                 record[attributeName] = [originalObject valueForKey:attributeName];
             }
         }];


### PR DESCRIPTION
If primaryKey attribute can't be uploaded, that will be nil and that data lost forever. 
If relationship consists of Entity.name and primaryKey, that will be nil too. Finally, if you would like to delete it, it causes crashes too. With this little change could be solved all these issues. 
Earlier it worked, if it was used just at 1 Entity on the higher level because it hasn't any other parent Entity, so there was no problem with relationships, just the nil attribute, which could come back in the app because of the relationship with child Entity was live.  