### PR TITLE
CKModifyRecordsOperation.isAtomic

### DIFF
--- a/SyncKit/Classes/QSSynchronizer/QSCloudKitSynchronizer.m
+++ b/SyncKit/Classes/QSSynchronizer/QSCloudKitSynchronizer.m
@@ -408,7 +408,7 @@ NSString * const QSCloudKitModelCompatibilityVersionKey = @"QSCloudKitModelCompa
         [self addMetadataToRecords:records];
         //Now perform the operation
         CKModifyRecordsOperation *modifyRecordsOperation = [[CKModifyRecordsOperation alloc] initWithRecordsToSave:records recordIDsToDelete:nil];
-        
+        modifyRecordsOperation.atomic=NO;
         NSMutableArray *recordsToSave = [NSMutableArray array];
         modifyRecordsOperation.perRecordCompletionBlock = ^(CKRecord *record, NSError *error) {
             dispatch_async(self.dispatchQueue, ^{
@@ -465,6 +465,7 @@ NSString * const QSCloudKitModelCompatibilityVersionKey = @"QSCloudKitModelCompa
     } else {
         //Now perform the operation
         CKModifyRecordsOperation *modifyRecordsOperation = [[CKModifyRecordsOperation alloc] initWithRecordsToSave:nil recordIDsToDelete:recordIDs];
+        modifyRecordsOperation.atomic=NO;
         modifyRecordsOperation.modifyRecordsCompletionBlock = ^(NSArray <CKRecord *> *savedRecords, NSArray <CKRecordID *> *deletedRecordIDs, NSError *operationError) {
             dispatch_async(self.dispatchQueue, ^{
                 DLog(@"QSCloudKitSynchronizer >> Deleted %ld records", (unsigned long)deletedRecordIDs.count);


### PR DESCRIPTION
set `modifyRecordsOperation.atomic=NO;`

> If your client is compiled against iOS 11, operations enqueued against the default CKRecordZone have new behavior because atomic is true by default. If the operation hits a "preflight" failure (most commonly, a network issue uploading a CKAsset, or a malformed CKRecord), the entire operation is canceled. (30838858)