### PR TITLE
Update QSCloudKitSynchronizer+CoreData.m latest IOS+WatchOS

### DIFF
--- a/SyncKit/Classes/CoreData/QSCloudKitSynchronizer+CoreData.m
+++ b/SyncKit/Classes/CoreData/QSCloudKitSynchronizer+CoreData.m
@@ -54,7 +54,11 @@ static NSString * const QSCloudKitCustomZoneName = @"QSCloudKitCustomZoneName";
 
 + (CKRecordZoneID *)defaultCustomZoneID
 {
-    return [[CKRecordZoneID alloc] initWithZoneName:QSCloudKitCustomZoneName ownerName:CKOwnerDefaultName];
+    if (@available(iOS 10.0, macOS 10.12, watchOS 3.0, *)) {
+        return [[CKRecordZoneID alloc] initWithZoneName:QSCloudKitCustomZoneName ownerName:CKCurrentUserDefaultName]
+    }else{
+        return [[CKRecordZoneID alloc] initWithZoneName:QSCloudKitCustomZoneName ownerName:CKOwnerDefaultName];
+    }
 }
 
 + (QSCloudKitSynchronizer *)cloudKitSynchronizerWithContainerName:(NSString *)containerName managedObjectContext:(NSManagedObjectContext *)context changeManagerDelegate:(id<QSCoreDataChangeManagerDelegate>)delegate


### PR DESCRIPTION
using CKCurrentUserDefaultName at iOS 10.0, macOS 10.12, watchOS 3.0 or greater, instead of CKOwnerDefaultName - maybe this changes need more effort to check changes between records and  need to check the scenario if the user has more devices with different ios versions