### PR TITLE
missing completion handler call

### DIFF
--- a/SyncKit/Classes/QSSynchronizer/CloudKitSynchronizer+Sharing.swift
+++ b/SyncKit/Classes/QSSynchronizer/CloudKitSynchronizer+Sharing.swift
@@ -69,6 +69,7 @@ import CloudKit
         
         guard let modelAdapter = modelAdapter(for: object),
             let record = modelAdapter.record(for: object) else {
+                completion?(nil, nil)
                 return
         }
         let share = CKShare(rootRecord: record)

--- a/SyncKit/Classes/QSSynchronizer/CloudKitSynchronizer+Sharing.swift
+++ b/SyncKit/Classes/QSSynchronizer/CloudKitSynchronizer+Sharing.swift
@@ -69,7 +69,7 @@ import CloudKit
         
         guard let modelAdapter = modelAdapter(for: object),
             let record = modelAdapter.record(for: object) else {
-                completion?(nil, nil)
+                completion?(nil, CloudKitSynchronizer.SyncError.recordNotFound)
                 return
         }
         let share = CKShare(rootRecord: record)

--- a/SyncKit/Classes/QSSynchronizer/CloudKitSynchronizer.swift
+++ b/SyncKit/Classes/QSSynchronizer/CloudKitSynchronizer.swift
@@ -60,6 +60,7 @@ public class CloudKitSynchronizer: NSObject {
     @objc public enum SyncError: Int, Error {
         case alreadySyncing
         case higherModelVersionFound
+        case recordNotFound
         case cancelled
     }
     


### PR DESCRIPTION
It looks like to be a bug here - if a method has a completion block I suppose it to be called before returning from the method (always or at least in most circumstances).