### PR TITLE
deleted zone returned as changed

### DIFF
--- a/SyncKit/Classes/QSSynchronizer/CloudKitSynchronizer+Sync.swift
+++ b/SyncKit/Classes/QSSynchronizer/CloudKitSynchronizer+Sync.swift
@@ -228,8 +228,15 @@ extension CloudKitSynchronizer {
                 for (zoneID, result) in zoneResults {
                     let adapter = self.modelAdapterDictionary[zoneID]
                     if let resultError = result.error {
-                        error = resultError
-                        break
+                        if (self.isZoneNotFoundOrDeletedError(error))
+                        {
+                            self.notifyProviderForDeletedZoneIDs([zoneID])
+                        }
+                        else
+                        {
+                            error = resultError
+                            break
+                        }
                     } else {
                         debugPrint("QSCloudKitSynchronizer >> Downloaded \(result.downloadedRecords.count) changed records >> from zone \(zoneID.description)")
                         debugPrint("QSCloudKitSynchronizer >> Downloaded \(result.deletedRecordIDs.count) deleted record IDs >> from zone \(zoneID.description)")


### PR DESCRIPTION
Here is a fix for that strange issue, that I sometimes see. Rarely, but it happened several times - deleted zone for some reason returned as changed during fetchDatabaseChangesOperation, but when fetching that zone changes, you get zone not found/or deleted error. Steps to reproduce unknown. But this should fix such case I think.