### PR TITLE
Adding missing ModifyRecordsOperation.swift to XCode projects

### DIFF
--- a/Example/CoreData/SyncKitCoreDataIOS/SyncKitCoreDataiOS.xcodeproj/project.pbxproj
+++ b/Example/CoreData/SyncKitCoreDataIOS/SyncKitCoreDataiOS.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		648D93DF22CBEF3700C01529 /* CloudKitSynchronizerOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648D93DC22CBEF3700C01529 /* CloudKitSynchronizerOperation.swift */; };
 		648D93E022CBEF3700C01529 /* FetchZoneChangesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648D93DD22CBEF3700C01529 /* FetchZoneChangesOperation.swift */; };
 		64B3A3BA22B54AF000E4E942 /* QSManagedObjectContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B3A3B922B54AEF00E4E942 /* QSManagedObjectContext.swift */; };
+		AD0F7E42251BDFA6009F20D3 /* ModifyRecordsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0F7E41251BDFA6009F20D3 /* ModifyRecordsOperation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -90,6 +91,7 @@
 		648D93DC22CBEF3700C01529 /* CloudKitSynchronizerOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CloudKitSynchronizerOperation.swift; path = ../../../../../SyncKit/Classes/QSSynchronizer/Operations/CloudKitSynchronizerOperation.swift; sourceTree = "<group>"; };
 		648D93DD22CBEF3700C01529 /* FetchZoneChangesOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FetchZoneChangesOperation.swift; path = ../../../../../SyncKit/Classes/QSSynchronizer/Operations/FetchZoneChangesOperation.swift; sourceTree = "<group>"; };
 		64B3A3B922B54AEF00E4E942 /* QSManagedObjectContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = QSManagedObjectContext.swift; path = ../../../../../SyncKit/Classes/CoreData/QSManagedObjectContext.swift; sourceTree = "<group>"; };
+		AD0F7E41251BDFA6009F20D3 /* ModifyRecordsOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ModifyRecordsOperation.swift; path = ../../../../../SyncKit/Classes/QSSynchronizer/Operations/ModifyRecordsOperation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -177,6 +179,7 @@
 				648D93DC22CBEF3700C01529 /* CloudKitSynchronizerOperation.swift */,
 				648D93DB22CBEF3700C01529 /* FetchDatabaseChangesOperation.swift */,
 				648D93DD22CBEF3700C01529 /* FetchZoneChangesOperation.swift */,
+				AD0F7E41251BDFA6009F20D3 /* ModifyRecordsOperation.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -262,6 +265,7 @@
 			files = (
 				648D93D922CBEF3000C01529 /* CloudKitSynchronizer+Subscriptions.swift in Sources */,
 				648D93D022CBEF3000C01529 /* CloudKitSynchronizer+Private.swift in Sources */,
+				AD0F7E42251BDFA6009F20D3 /* ModifyRecordsOperation.swift in Sources */,
 				640C334F22A98F7F00A85508 /* CoreDataAdapter+Notifications.swift in Sources */,
 				648D93D822CBEF3000C01529 /* CloudKitSynchronizer.swift in Sources */,
 				648D93DA22CBEF3000C01529 /* SyncedEntityState.swift in Sources */,

--- a/Example/CoreData/SyncKitCoreDataOSX/SyncKitCoreDataOSX.xcodeproj/project.pbxproj
+++ b/Example/CoreData/SyncKitCoreDataOSX/SyncKitCoreDataOSX.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		649236F922C7C1460074A142 /* QSSyncedEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6433B40522C006D000EAC16C /* QSSyncedEntity+CoreDataClass.swift */; };
 		649236FA22C7C1460074A142 /* QSSyncedEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6433B40C22C006D000EAC16C /* QSSyncedEntity+CoreDataProperties.swift */; };
 		649236FB22C7C14D0074A142 /* QSCloudKitSyncModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 6433B40E22C006D100EAC16C /* QSCloudKitSyncModel.xcdatamodeld */; };
+		AD0F7E46251BE005009F20D3 /* ModifyRecordsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0F7E45251BE005009F20D3 /* ModifyRecordsOperation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -89,6 +90,7 @@
 		648D93F322CBEF5600C01529 /* CloudKitSynchronizer+Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "CloudKitSynchronizer+Sync.swift"; path = "../../../../../SyncKit/Classes/QSSynchronizer/CloudKitSynchronizer+Sync.swift"; sourceTree = "<group>"; };
 		648D93F422CBEF5600C01529 /* ModelAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ModelAdapter.swift; path = ../../../../../SyncKit/Classes/QSSynchronizer/ModelAdapter.swift; sourceTree = "<group>"; };
 		649236DF22C7C1230074A142 /* SyncKitCoreDataOSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SyncKitCoreDataOSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AD0F7E45251BE005009F20D3 /* ModifyRecordsOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ModifyRecordsOperation.swift; path = ../../../../../SyncKit/Classes/QSSynchronizer/Operations/ModifyRecordsOperation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,6 +165,7 @@
 				648D93E422CBEF4D00C01529 /* CloudKitSynchronizerOperation.swift */,
 				648D93E222CBEF4D00C01529 /* FetchDatabaseChangesOperation.swift */,
 				648D93E322CBEF4D00C01529 /* FetchZoneChangesOperation.swift */,
+				AD0F7E45251BE005009F20D3 /* ModifyRecordsOperation.swift */,
 				648D93EF22CBEF5600C01529 /* BackupDetection.swift */,
 				648D93F022CBEF5600C01529 /* CloudKitDatabase.swift */,
 				648D93EB22CBEF5600C01529 /* CloudKitSynchronizer.swift */,
@@ -259,6 +262,7 @@
 			files = (
 				648D93FF22CBEF5600C01529 /* KeyValueStore.swift in Sources */,
 				648D93FD22CBEF5600C01529 /* CloudKitDatabase.swift in Sources */,
+				AD0F7E46251BE005009F20D3 /* ModifyRecordsOperation.swift in Sources */,
 				649236FB22C7C14D0074A142 /* QSCloudKitSyncModel.xcdatamodeld in Sources */,
 				649236ED22C7C1430074A142 /* CoreDataStack.swift in Sources */,
 				649236F322C7C1460074A142 /* QSPendingRelationship+CoreDataClass.swift in Sources */,

--- a/Example/Realm/SyncKitRealmIOS/SyncKitRealmiOS.xcodeproj/project.pbxproj
+++ b/Example/Realm/SyncKitRealmIOS/SyncKitRealmiOS.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		6492367922C67F650074A142 /* CloudKitSynchronizer+MultiRealmResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6492367822C67F650074A142 /* CloudKitSynchronizer+MultiRealmResultsController.swift */; };
 		6492367B22C67F8A0074A142 /* CloudKitSynchronizer+Realm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6492367A22C67F8A0074A142 /* CloudKitSynchronizer+Realm.swift */; };
 		6492369222C6941B0074A142 /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6492369122C6941B0074A142 /* RLMSupport.swift */; };
+		AD0F7E4F251BF11A009F20D3 /* ModifyRecordsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0F7E4E251BF11A009F20D3 /* ModifyRecordsOperation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -69,6 +70,7 @@
 		6492367822C67F650074A142 /* CloudKitSynchronizer+MultiRealmResultsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "CloudKitSynchronizer+MultiRealmResultsController.swift"; path = "../../../../../SyncKit/Classes/Realm/CloudKitSynchronizer+MultiRealmResultsController.swift"; sourceTree = "<group>"; };
 		6492367A22C67F8A0074A142 /* CloudKitSynchronizer+Realm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "CloudKitSynchronizer+Realm.swift"; path = "../../../../../SyncKit/Classes/Realm/CloudKitSynchronizer+Realm.swift"; sourceTree = "<group>"; };
 		6492369122C6941B0074A142 /* RLMSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RLMSupport.swift; path = ../../../../../SyncKit/Classes/Realm/RLMSupport.swift; sourceTree = "<group>"; };
+		AD0F7E4E251BF11A009F20D3 /* ModifyRecordsOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ModifyRecordsOperation.swift; path = ../../../../../SyncKit/Classes/QSSynchronizer/Operations/ModifyRecordsOperation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,6 +118,7 @@
 				648D948922CD231B00C01529 /* CloudKitSynchronizerOperation.swift */,
 				648D948B22CD231B00C01529 /* FetchDatabaseChangesOperation.swift */,
 				648D948A22CD231B00C01529 /* FetchZoneChangesOperation.swift */,
+				AD0F7E4E251BF11A009F20D3 /* ModifyRecordsOperation.swift */,
 				648D947822CD231500C01529 /* BackupDetection.swift */,
 				648D946F22CD231400C01529 /* CloudKitDatabase.swift */,
 				648D947B22CD231500C01529 /* CloudKitSynchronizer.swift */,
@@ -232,6 +235,7 @@
 			files = (
 				648D948E22CD231B00C01529 /* FetchDatabaseChangesOperation.swift in Sources */,
 				648D948122CD231500C01529 /* CloudKitSynchronizer+Private.swift in Sources */,
+				AD0F7E4F251BF11A009F20D3 /* ModifyRecordsOperation.swift in Sources */,
 				6492367322C67DD40074A142 /* DefaultRealmSwiftAdapterProvider.swift in Sources */,
 				648D948D22CD231B00C01529 /* FetchZoneChangesOperation.swift in Sources */,
 				6492369222C6941B0074A142 /* RLMSupport.swift in Sources */,

--- a/Example/Realm/SyncKitRealmOSX/SyncKitRealmOSX.xcodeproj/project.pbxproj
+++ b/Example/Realm/SyncKitRealmOSX/SyncKitRealmOSX.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		648D94C422CD233E00C01529 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648D94B922CD233E00C01529 /* Record.swift */; };
 		648D94C522CD233E00C01529 /* DefaultRealmProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648D94BA22CD233E00C01529 /* DefaultRealmProvider.swift */; };
 		648D94C622CD233E00C01529 /* MultiRealmResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648D94BB22CD233E00C01529 /* MultiRealmResultsController.swift */; };
+		AD0F7E52251BF197009F20D3 /* ModifyRecordsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0F7E51251BF197009F20D3 /* ModifyRecordsOperation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -68,6 +69,7 @@
 		648D94BB22CD233E00C01529 /* MultiRealmResultsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MultiRealmResultsController.swift; path = ../../../../../SyncKit/Classes/Realm/MultiRealmResultsController.swift; sourceTree = "<group>"; };
 		6492365D22C66CEF0074A142 /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Realm.framework; sourceTree = "<group>"; };
 		6492369A22C694610074A142 /* SyncKitRealmOSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SyncKitRealmOSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AD0F7E51251BF197009F20D3 /* ModifyRecordsOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ModifyRecordsOperation.swift; path = ../../../../../SyncKit/Classes/QSSynchronizer/Operations/ModifyRecordsOperation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -128,6 +130,7 @@
 				648D949322CD233000C01529 /* CloudKitSynchronizerOperation.swift */,
 				648D949122CD233000C01529 /* FetchDatabaseChangesOperation.swift */,
 				648D949222CD233000C01529 /* FetchZoneChangesOperation.swift */,
+				AD0F7E51251BF197009F20D3 /* ModifyRecordsOperation.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -230,6 +233,7 @@
 			files = (
 				648D94B022CD233700C01529 /* CloudKitSynchronizer+Private.swift in Sources */,
 				648D94C122CD233E00C01529 /* RLMSupport.swift in Sources */,
+				AD0F7E52251BF197009F20D3 /* ModifyRecordsOperation.swift in Sources */,
 				648D94C422CD233E00C01529 /* Record.swift in Sources */,
 				648D94AB22CD233700C01529 /* KeyValueStore.swift in Sources */,
 				648D94A922CD233700C01529 /* CloudKitSynchronizer+Subscriptions.swift in Sources */,


### PR DESCRIPTION
Commit 714f5e75967ea0783943a2de6927b1996c7c8b9c breaks Carthage builds with the error: `error: cannot find 'ModifyRecordsOperation' in scope`