### PR TITLE
Fix for infinite loop if (somehow) a duplicate identifier exists

### DIFF
--- a/SyncKit/Classes/CoreData/CoreDataAdapter+Private.swift
+++ b/SyncKit/Classes/CoreData/CoreDataAdapter+Private.swift
@@ -254,7 +254,7 @@ extension CoreDataAdapter {
             var pending = entities
             var includedEntityIDs = Set<String>()
             while recordsArray.count < limit && !pending.isEmpty {
-                var entity: QSSyncedEntity! = pending.last
+                var entity: QSSyncedEntity! = pending.removeLast()
                 while entity != nil && entity.entityState == state && !includedEntityIDs.contains(entity.identifier!) {
                     var parentEntity: QSSyncedEntity? = nil
                     if let index = pending.firstIndex(of: entity) {


### PR DESCRIPTION
I still need to figure out how I ended up with duplicates in the first place, but I figured out why my synchronize was never finishing and a background thread was consuming a processor core.