### PR TITLE
Support for Int primary key in RealmSwiftAdapter

### DIFF
--- a/SyncKit/Classes/RealmSwift/RealmSwiftAdapter.swift
+++ b/SyncKit/Classes/RealmSwift/RealmSwiftAdapter.swift
@@ -191,7 +191,6 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
             let primaryKey = objectClass.primaryKey()!
             let results = realmProvider.targetRealm.objects(objectClass)
             
-            debugPrint("Registering for collection notifications...")
             // Register for collection notifications
             let token = results.observe({ [weak self] (collectionChange) in
                 
@@ -218,7 +217,6 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
             })
             collectionNotificationTokens.append(token)
             
-            debugPrint("Registering for object updates...")
             // Register for object updates
             for object in results {
                 
@@ -250,7 +248,7 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
                 })
                 
                 if needsInitialSetup {
-                    debugPrint("Needs initial setup...creating synced entity...")
+                    
                     createSyncedEntity(entityType: schema.className, identifier: identifier, realm: realmProvider.persistenceRealm)
                 }
                 
@@ -426,7 +424,7 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
     }
     
     func commitTargetWriteTransactionWithoutNotifying() {
-        debugPrint("Performing commit write in target Realm...")
+        
         try? realmProvider.targetRealm.commitWrite(withoutNotifying: Array(objectNotificationTokens.values))
     }
     
@@ -443,7 +441,7 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
     }
     
     func createSyncedEntity(record: CKRecord, realmProvider: RealmProvider) -> SyncedEntity {
-        debugPrint("Creating synced entity from CKRecord...")
+        
         let syncedEntity = SyncedEntity(entityType: record.recordType, identifier: record.recordID.recordName, state: SyncedEntityState.synced.rawValue)
         
         realmProvider.persistenceRealm.add(syncedEntity)
@@ -461,17 +459,14 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
     
     func getObjectIdentifier(for syncedEntity: SyncedEntity) -> Any? {
 
-        debugPrint("Getting object identifier for the synced entity with entity type \(syncedEntity.entityType) and identifier \(syncedEntity.identifier)")
         let range = syncedEntity.identifier.range(of: syncedEntity.entityType)!
         let index = syncedEntity.identifier.index(range.upperBound, offsetBy: 1)
         let objectIdentifier = String(syncedEntity.identifier[index...])
-        debugPrint("Object identifier is: \(objectIdentifier)")
         
         let objectClass = realmObjectClass(name: syncedEntity.entityType)
         let primaryKey = objectClass.primaryKey()!
         let object = objectClass.init()
         let primaryKeyType = object.objectSchema[primaryKey]?.type
-        debugPrint("Primary key type: \(String(describing: primaryKeyType))")
                 
         return PropertyType.int == primaryKeyType ? Int(objectIdentifier) : objectIdentifier
     }
@@ -641,7 +636,7 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
     }
     
     func applyPendingRelationships(realmProvider: RealmProvider) {
-        debugPrint("Applying pending relationships...")
+        
         let pendingRelationships = realmProvider.persistenceRealm.objects(PendingRelationship.self)
         
         if pendingRelationships.count == 0 {
@@ -799,7 +794,6 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
     
     func recordToUpload(syncedEntity: SyncedEntity, realmProvider: RealmProvider, parentSyncedEntity: inout SyncedEntity?) -> CKRecord {
         
-        debugPrint("Getting the record to upload...")
         let record = getRecord(for: syncedEntity) ?? CKRecord(recordType: syncedEntity.entityType, recordID: CKRecord.ID(recordName: syncedEntity.identifier, zoneID: zoneID))
         
         let objectClass = realmObjectClass(name: syncedEntity.entityType)

--- a/SyncKit/Classes/RealmSwift/RealmSwiftAdapter.swift
+++ b/SyncKit/Classes/RealmSwift/RealmSwiftAdapter.swift
@@ -452,26 +452,35 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
         let primaryKey = objectClass.primaryKey()!
         let objectIdentifier = getObjectIdentifier(for: syncedEntity)
         let object = objectClass.init()
-        let primaryKeyType = object.objectSchema[primaryKey]?.type
-        if PropertyType.int == primaryKeyType {
-            object.setValue(Int(objectIdentifier), forKey: primaryKey)
-        } else {
-            object.setValue(objectIdentifier, forKey: primaryKey)
-        }
+        object.setValue(objectIdentifier, forKey: primaryKey)
         realmProvider.targetRealm.add(object)
         
         return syncedEntity;
 
     }
     
-    func getObjectIdentifier(for syncedEntity: SyncedEntity) -> String {
+    func getObjectIdentifier(for syncedEntity: SyncedEntity) -> Any? {
 
         debugPrint("Getting object identifier for the synced entity with entity type \(syncedEntity.entityType) and identifier \(syncedEntity.identifier)")
         let range = syncedEntity.identifier.range(of: syncedEntity.entityType)!
         let index = syncedEntity.identifier.index(range.upperBound, offsetBy: 1)
         let objectIdentifier = String(syncedEntity.identifier[index...])
         debugPrint("Object identifier is: \(objectIdentifier)")
-        return objectIdentifier
+        
+        let objectClass = realmObjectClass(name: syncedEntity.entityType)
+        let primaryKey = objectClass.primaryKey()!
+        let object = objectClass.init()
+        let primaryKeyType = object.objectSchema[primaryKey]?.type
+        debugPrint("Primary key type: \(String(describing: primaryKeyType))")
+                
+        return PropertyType.int == primaryKeyType ? Int(objectIdentifier) : objectIdentifier
+    }
+    
+    func getStringObjectIdentifier(_ objectIdentifier: Any?) -> String {
+        if let identifier = objectIdentifier as? Int {
+            return String(identifier)
+        }
+        return objectIdentifier as! String
     }
     
     func syncedEntity(for object: Object, realm: Realm) -> SyncedEntity? {
@@ -976,13 +985,14 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
                         
                         let objectClass = realmObjectClass(name: syncedEntity.entityType)
                         let objectIdentifier = getObjectIdentifier(for: syncedEntity)
+                        let stringObjectIdentifier = getStringObjectIdentifier(objectIdentifier)
                         let object = self.realmProvider.targetRealm.object(ofType: objectClass, forPrimaryKey: objectIdentifier)
                         
                         if let object = object {
                             
-                            if let token = objectNotificationTokens[objectIdentifier] {
+                            if let token = objectNotificationTokens[stringObjectIdentifier] {
                                 DispatchQueue.main.async {
-                                    self.objectNotificationTokens.removeValue(forKey: objectIdentifier)
+                                    self.objectNotificationTokens.removeValue(forKey: stringObjectIdentifier)
                                     token.invalidate()
                                 }
                             }

--- a/SyncKit/Classes/RealmSwift/RealmSwiftAdapter.swift
+++ b/SyncKit/Classes/RealmSwift/RealmSwiftAdapter.swift
@@ -450,7 +450,12 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
         let primaryKey = objectClass.primaryKey()!
         let objectIdentifier = getObjectIdentifier(for: syncedEntity)
         let object = objectClass.init()
-        object.setValue(objectIdentifier, forKey: primaryKey)
+        let primaryKeyType = object.objectSchema[primaryKey]?.type
+        if PropertyType.int == primaryKeyType {
+            object.setValue(Int(objectIdentifier), forKey: primaryKey)
+        } else {
+            object.setValue(objectIdentifier, forKey: primaryKey)
+        }
         realmProvider.targetRealm.add(object)
         
         return syncedEntity;

--- a/SyncKit/Classes/RealmSwift/RealmSwiftAdapter.swift
+++ b/SyncKit/Classes/RealmSwift/RealmSwiftAdapter.swift
@@ -200,16 +200,16 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
                     for index in insertions {
                         
                         let object = results[index]
-                        let identifier = getIdentifier(for: object, primaryKey: primaryKey)
+                        let identifier = self?.getIdentifier(for: object, primaryKey: primaryKey)
                         /* This can be called during a transaction, and it's illegal to add a notification block during a transaction,
                          * so we keep all the insertions in a list to be processed as soon as the realm finishes the current transaction
                          */
                         if object.realm!.isInWriteTransaction {
                             
-                            self?.pendingTrackingUpdates.append(ObjectUpdate(object: object, identifier: identifier, entityType: schema.className, updateType: .insertion, changes: nil))
+                            self?.pendingTrackingUpdates.append(ObjectUpdate(object: object, identifier: identifier!, entityType: schema.className, updateType: .insertion, changes: nil))
                         } else {
                             
-                            self?.updateTracking(insertedObject: object, identifier: identifier, entityName: schema.className, provider: self!.realmProvider)
+                            self?.updateTracking(insertedObject: object, identifier: identifier!, entityName: schema.className, provider: self!.realmProvider)
                         }
                     }
                 default: break
@@ -220,7 +220,7 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
             // Register for object updates
             for object in results {
                 
-                let identifier = getIdentifier(for: object, primaryKey: primaryKey)
+                let identifier = self.getIdentifier(for: object, primaryKey: primaryKey)
                 let token = object.observe({ [weak self] (change) in
                     
                     switch change {

--- a/SyncKit/Classes/RealmSwift/RealmSwiftAdapter.swift
+++ b/SyncKit/Classes/RealmSwift/RealmSwiftAdapter.swift
@@ -219,8 +219,15 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
             
             // Register for object updates
             for object in results {
+                var identifier: String = ""
+                let objectId = object.value(forKey: primaryKey)
                 
-                let identifier = object.value(forKey: primaryKey) as! String
+                if let id = objectId as? Int {
+                    identifier = String(id)
+                } else {
+                    identifier = objectId as! String
+                }
+                
                 let token = object.observe({ [weak self] (change) in
                     
                     switch change {

--- a/SyncKit/Classes/RealmSwift/RealmSwiftAdapter.swift
+++ b/SyncKit/Classes/RealmSwift/RealmSwiftAdapter.swift
@@ -200,7 +200,7 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
                     for index in insertions {
                         
                         let object = results[index]
-                        let identifier = object.value(forKey: primaryKey) as! String
+                        let identifier = getIdentifier(for: object, primaryKey: primaryKey)
                         /* This can be called during a transaction, and it's illegal to add a notification block during a transaction,
                          * so we keep all the insertions in a list to be processed as soon as the realm finishes the current transaction
                          */
@@ -219,15 +219,8 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
             
             // Register for object updates
             for object in results {
-                var identifier: String = ""
-                let objectId = object.value(forKey: primaryKey)
                 
-                if let id = objectId as? Int {
-                    identifier = String(id)
-                } else {
-                    identifier = objectId as! String
-                }
-                
+                let identifier = getIdentifier(for: object, primaryKey: primaryKey)
                 let token = object.observe({ [weak self] (change) in
                     
                     switch change {
@@ -475,8 +468,20 @@ public class RealmSwiftAdapter: NSObject, ModelAdapter {
         
         let objectClass = realmObjectClass(name: object.objectSchema.className)
         let primaryKey = objectClass.primaryKey()!
-        let identifier = object.objectSchema.className + "." + (object.value(forKey: primaryKey) as! String)
+        let identifier = object.objectSchema.className + "." + getIdentifier(for: object, primaryKey: primaryKey)
         return getSyncedEntity(objectIdentifier: identifier, realm: realm)
+    }
+    
+    func getIdentifier(for object: Object, primaryKey: String) -> String {
+        var identifier: String = ""
+        let objectId = object.value(forKey: primaryKey)
+        
+        if let id = objectId as? Int {
+            identifier = String(id)
+        } else {
+            identifier = objectId as! String
+        }
+        return identifier
     }
     
     func getSyncedEntity(objectIdentifier: String, realm: Realm) -> SyncedEntity? {


### PR DESCRIPTION
Ref: #147 

Hi @mentrena 
I've made some attempt to support Int primary key in RealmSwiftAdapter.
I've tested this in my app and it works. My app has entities with both Int and String primary keys. Entities using both types of primary key were synced properly.
Please let me know if I need to make any improvements.