### PR TITLE
Fix `SyncKit/CoreData` in SwiftPM.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Realm", package: "realm-cocoa")
             ],
-            sources: ["SyncKit/Classes/Realm"]
+            path: "SyncKit/Classes/Realm"
         ),
         .target(
             name: "SyncKit/RealmSwift",
@@ -38,7 +38,7 @@ let package = Package(
                 .product(name: "RealmSwift", package: "realm-cocoa"),
                 .product(name: "Realm", package: "realm-cocoa")
             ],
-            sources: ["SyncKit/Classes/RealmSwift"]
+            path: "SyncKit/Classes/RealmSwift"
         )
     ],
     swiftLanguageVersions: [.v5]

--- a/Package.swift
+++ b/Package.swift
@@ -20,9 +20,9 @@ let package = Package(
         .target(
             name: "SyncKit/CoreData",
             dependencies: [],
-            sources: ["SyncKit/Classes/CoreData"],
+            path: "SyncKit/Classes/CoreData",
             resources: [
-                .process("SyncKit/Classes/CoreData/QSCloudKitSyncModel.xcdatamodeld")
+                .process("QSCloudKitSyncModel.xcdatamodeld")
             ]
         ),
          .target(

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
             dependencies: [
                 .byName(name: "RealmSwift"),
                 .byName(name: "Realm")
-            ]
+            ],
             path: ".",
             sources: ["SyncKit/Classes/RealmSwift"]
         )

--- a/Package.swift
+++ b/Package.swift
@@ -26,13 +26,18 @@ let package = Package(
         ),
          .target(
             name: "SyncKit/Realm",
-            dependencies: ["Realm"],
+            dependencies: [
+                .byName(name: "Realm")
+            ],
             path: ".",
             sources: ["SyncKit/Classes/Realm"]
         ),
         .target(
             name: "SyncKit/RealmSwift",
-            dependencies: ["RealmSwift", "Realm"],
+            dependencies: [
+                .byName(name: "RealmSwift"),
+                .byName(name: "Realm"])
+            ]
             path: ".",
             sources: ["SyncKit/Classes/RealmSwift"]
         )

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
             name: "SyncKit/CoreData",
             dependencies: [],
             path: ".",
+            exclude: ["Example"],
             sources: ["SyncKit/Classes/CoreData"],
             resources: [
                 .process("SyncKit/Classes/CoreData/QSCloudKitSyncModel.xcdatamodeld")
@@ -32,6 +33,7 @@ let package = Package(
                 .product(name: "Realm", package: "realm-cocoa")
             ],
             path: ".",
+            exclude: ["Example"],
             sources: ["SyncKit/Classes/Realm"]
         ),
         .target(
@@ -41,6 +43,7 @@ let package = Package(
                 .product(name: "Realm", package: "realm-cocoa")
             ],
             path: ".",
+            exclude: ["Example"],
             sources: ["SyncKit/Classes/RealmSwift"]
         )
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,9 @@ let package = Package(
             path: "SyncKit/Classes/CoreData",
             resources: [
                 .process("QSCloudKitSyncModel.xcdatamodeld")
+            ],
+            swiftSettings: [
+                .define("SPM")
             ]
         ),
          .target(

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,6 @@ let package = Package(
         .target(
             name: "SyncKit/CoreData",
             dependencies: [],
-            path: ".",
-            exclude: ["Example"],
             sources: ["SyncKit/Classes/CoreData"],
             resources: [
                 .process("SyncKit/Classes/CoreData/QSCloudKitSyncModel.xcdatamodeld")
@@ -32,8 +30,6 @@ let package = Package(
             dependencies: [
                 .product(name: "Realm", package: "realm-cocoa")
             ],
-            path: ".",
-            exclude: ["Example"],
             sources: ["SyncKit/Classes/Realm"]
         ),
         .target(
@@ -42,8 +38,6 @@ let package = Package(
                 .product(name: "RealmSwift", package: "realm-cocoa"),
                 .product(name: "Realm", package: "realm-cocoa")
             ],
-            path: ".",
-            exclude: ["Example"],
             sources: ["SyncKit/Classes/RealmSwift"]
         )
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
          .target(
             name: "SyncKit/Realm",
             dependencies: [
-                .byName(name: "Realm")
+                .product(name: "Realm", package: "realm-cocoa")
             ],
             path: ".",
             sources: ["SyncKit/Classes/Realm"]
@@ -35,8 +35,8 @@ let package = Package(
         .target(
             name: "SyncKit/RealmSwift",
             dependencies: [
-                .byName(name: "RealmSwift"),
-                .byName(name: "Realm")
+                .product(name: "RealmSwift", package: "realm-cocoa"),
+                .product(name: "Realm", package: "realm-cocoa")
             ],
             path: ".",
             sources: ["SyncKit/Classes/RealmSwift"]

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
             name: "SyncKit/CoreData",
             dependencies: [],
             path: ".",
-            sources: ["SyncKit/Classes/CoreData"]
+            sources: ["SyncKit/Classes/CoreData"],
+            resources: [.process("SyncKit/Classes/CoreData")]
         ),
          .target(
             name: "SyncKit/Realm",

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
             name: "SyncKit/RealmSwift",
             dependencies: [
                 .byName(name: "RealmSwift"),
-                .byName(name: "Realm"])
+                .byName(name: "Realm")
             ]
             path: ".",
             sources: ["SyncKit/Classes/RealmSwift"]

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,9 @@ let package = Package(
             dependencies: [],
             path: ".",
             sources: ["SyncKit/Classes/CoreData"],
-            resources: [.process("SyncKit/Classes/CoreData")]
+            resources: [
+                .process("SyncKit/Classes/CoreData/QSCloudKitSyncModel.xcdatamodeld")
+            ]
         ),
          .target(
             name: "SyncKit/Realm",

--- a/SyncKit/Classes/CoreData/CoreDataAdapter.swift
+++ b/SyncKit/Classes/CoreData/CoreDataAdapter.swift
@@ -64,7 +64,11 @@ import CloudKit
 
     /// The `NSManagedObjectModel` used by the model adapter to keep track of changes, internally.
     @objc class var persistenceModel: NSManagedObjectModel {
+        #if SPM
+        let modelURL = Bundle.module.url(forResource: "QSCloudKitSyncModel", withExtension: "momd")
+        #else
         let modelURL = Bundle(for: CoreDataAdapter.self).url(forResource: "QSCloudKitSyncModel", withExtension: "momd")
+        #endif
         return NSManagedObjectModel(contentsOf: modelURL!)!
     }
     


### PR DESCRIPTION
Previously in SwiftPM, `SyncKit/CoreData` doesn't work because `QSCloudKitSyncModel.xcdatamodeld` isn't included as a resource. Unfortunately SwiftPM only supports resources from `5.3`, so I updated `Package.swift` to use `5.3` syntax.

Sorry for pull request without discussions beforehand, and messy commits, since we're trying to deliver our app on time. Please squash before merge if you feel you need to, and please let me know if there's any potential breaking cases introduced in this change. 