### PR TITLE
transformable attributes sync fix for NSSecureUnarchiveFromDataTransformer

### DIFF
--- a/SyncKit/Classes/CoreData/CoreDataAdapter+Private.swift
+++ b/SyncKit/Classes/CoreData/CoreDataAdapter+Private.swift
@@ -63,6 +63,12 @@ extension CoreDataAdapter {
     func transformedValue(_ value: Any, valueTransformerName: String?) -> Any? {
         if let valueTransformerName = valueTransformerName {
             let transformer = ValueTransformer(forName: NSValueTransformerName(valueTransformerName))
+            if #available(iOS 12.0, *) {
+                if let secureUnarchiveTransformer = transformer as? NSSecureUnarchiveFromDataTransformer
+                {
+                    return secureUnarchiveTransformer.reverseTransformedValue(value)
+                }
+            }
             return transformer?.transformedValue(value)
         } else {
             return QSCoder.shared.data(from: value)
@@ -72,6 +78,12 @@ extension CoreDataAdapter {
     func reverseTransformedValue(_ value: Any, valueTransformerName: String?) -> Any? {
         if let valueTransformerName = valueTransformerName {
             let transformer = ValueTransformer(forName: NSValueTransformerName(valueTransformerName))
+            if #available(iOS 12.0, *) {
+                if let secureUnarchiveTransformer = transformer as? NSSecureUnarchiveFromDataTransformer
+                {
+                    return secureUnarchiveTransformer.transformedValue(value)
+                }
+            }
             return transformer?.reverseTransformedValue(value)
         } else if let data = value as? Data {
             return QSCoder.shared.object(from: data)

--- a/SyncKit/Classes/CoreData/CoreDataAdapter+Private.swift
+++ b/SyncKit/Classes/CoreData/CoreDataAdapter+Private.swift
@@ -63,7 +63,7 @@ extension CoreDataAdapter {
     func transformedValue(_ value: Any, valueTransformerName: String?) -> Any? {
         if let valueTransformerName = valueTransformerName {
             let transformer = ValueTransformer(forName: NSValueTransformerName(valueTransformerName))
-            if #available(iOS 12.0, *) {
+            if #available(iOS 12.0, OSX 10.14, watchOS 5.0, *) {
                 if let secureUnarchiveTransformer = transformer as? NSSecureUnarchiveFromDataTransformer
                 {
                     return secureUnarchiveTransformer.reverseTransformedValue(value)
@@ -78,7 +78,7 @@ extension CoreDataAdapter {
     func reverseTransformedValue(_ value: Any, valueTransformerName: String?) -> Any? {
         if let valueTransformerName = valueTransformerName {
             let transformer = ValueTransformer(forName: NSValueTransformerName(valueTransformerName))
-            if #available(iOS 12.0, *) {
+            if #available(iOS 12.0, OSX 10.14, watchOS 5.0, *) {
                 if let secureUnarchiveTransformer = transformer as? NSSecureUnarchiveFromDataTransformer
                 {
                     return secureUnarchiveTransformer.transformedValue(value)


### PR DESCRIPTION
As mentioned in #177  - `NSSecureUnarchiveFromDataTransformer` use "reversed" methods from basic `ValueTransformers`:
`transformedValue: `is being used when unarchiving Data and `reverseTransformedValue: `- when archiving some object to Data.
So, I suggest this code to fix #177  crash